### PR TITLE
Added project ID and name tags to measurement info structure

### DIFF
--- a/matlab/fiff_define_constants.m
+++ b/matlab/fiff_define_constants.m
@@ -574,6 +574,12 @@ FIFF.FIFF_UNITM_A    = -18;
 FIFF.FIFFB_MNE_EPOCHS_SELECTION    = 3800;  % the epochs selection
 FIFF.FIFFB_MNE_EPOCHS_DROP_LOG     = 3801;  % the drop log
 
+%
+% Project info
+%
+FIFF.FIFF_PROJ_ID   = 500;
+FIFF.FIFF_PROJ_NAME = 501;
+
 return
 
 end

--- a/matlab/fiff_read_meas_info.m
+++ b/matlab/fiff_read_meas_info.m
@@ -110,6 +110,8 @@ end
 dev_head_t=[];
 ctf_head_t=[];
 meas_date=[];
+proj_id = [];
+proj_name = [];
 p = 0;
 for k = 1:meas_info.nent
     kind = meas_info.dir(k).kind;
@@ -147,6 +149,12 @@ for k = 1:meas_info.nent
                     cand.to == FIFF.FIFFV_COORD_DEVICE
                 dev_head_t = fiff_invert_transform(cand);
             end
+        case FIFF.FIFF_PROJ_ID
+            tag = fiff_read_tag(fid,pos);
+            proj_id = tag.data;
+        case FIFF.FIFF_PROJ_NAME
+            tag = fiff_read_tag(fid,pos);
+            proj_name = tag.data;
     end
 end
 %
@@ -343,6 +351,8 @@ info.projs = projs;
 info.comps = comps;
 info.acq_pars = acq_pars;
 info.acq_stim = acq_stim;
+info.proj_id = proj_id;
+info.proj_name = proj_name;
 
 if open_here
     fclose(fid);


### PR DESCRIPTION
fiff_read_meas_info() would ignore the proj_id and proj_name tags, which is supported by the MNE-Python version of that function (see: https://github.com/mne-tools/mne-python/blob/master/mne/io/meas_info.py). I added support for that, when those tags are present.