### PR TITLE
Bugfix: Syntax incompatible with older versions of Matlab

### DIFF
--- a/matlab/fiff_read_extended_ch_info.m
+++ b/matlab/fiff_read_extended_ch_info.m
@@ -25,7 +25,8 @@ for k=1:length(chs)
     for p = 1:new.nent
         kind = new.dir(p).kind;
         if kind == FIFF.FIFF_CH_DACQ_NAME
-            data = fiff_read_tag(fid, new.dir(p).pos).data;
+            tag = fiff_read_tag(fid, new.dir(p).pos);
+            data = tag.data;
             ch_rename = [ch_rename; {ch.ch_name, data}];
             ch.ch_name = data;
             break


### PR DESCRIPTION
Reported on the Brainstorm user forum (example file included):
https://neuroimage.usc.edu/forums/t/error-importing-reviewing-raw-meg-fif-files/26029/3

Fix on the Brainstorm repo:
https://github.com/brainstorm-tools/brainstorm3/commit/dfd4a6b7cf66a76d9ed09549947f3340156d77a9

I haven't tested with all versions of Matlab to see when this syntax was accepted. I only tried with 2009b and got the same error reported by our user. 