### PR TITLE
ENH - allow to read double precision data

### DIFF
--- a/matlab/fiff_setup_read_raw.m
+++ b/matlab/fiff_setup_read_raw.m
@@ -169,6 +169,8 @@ for k = first:nent
                 nsamp = ent.size/(4*nchan);
             case FIFF.FIFFT_INT
                 nsamp = ent.size/(4*nchan);
+            case FIFF.FIFFT_DOUBLE
+                nsamp = ent.size/(8*nchan);
             otherwise
                 fclose(fid);
                 error(me,'Cannot handle data buffers of type %d',ent.type);


### PR DESCRIPTION
Hi all, I am working on more smooth fif-file writing in the FieldTrip fieldtrip2fiff function. I noticed that by default fif-files are written in single precision format, but that there's no principled objection against writing the numbers in double precision. At least I thought I read along those lines in the documentation of MNE-python. This PR is needed to allow FieldTrip to do a round trip (i.e. write a FieldTrip raw data structure as a fif-file, and read it back in without precision loss), since it is relying on mne-matlab for the reading and the writing.

I'd be happy to be given pointers to where additional code tweaks (for consistency) are also required (e.g. does fiff_start_writing_raw need to be extended with an optional precision input argument?), and to be pointed to required tests to be done before this PR is considered seriously.